### PR TITLE
[component] Add return code constants for FW auto update to component_base

### DIFF
--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -5,6 +5,15 @@
     to interact with a chassis/module component (e.g., BIOS, CPLD, FPGA, etc.) in SONiC
 """
 
+# Return codes for firmware updates
+
+FW_AUTO_INSTALLED = 1
+FW_AUTO_UPDATED = 2
+FW_AUTO_SCHEDULED = 3
+FW_AUTO_ERR_BOOT_TYPE = -1
+FW_AUTO_ERR_IMAGE = -2
+FW_AUTO_ERR_UKNOWN = -3
+
 
 class ComponentBase(object):
     """


### PR DESCRIPTION
#### Description
Added constants to component_base for each potential return code of `auto_firmware_update()` so that vendor specific component implementations may reference these to provide the correct return codes to the firmware auto update utility. 

#### Motivation and Context
This provides a central location from which standardized return codes may be imported, preventing the need for potential inconsistency in vendor implementations or the use of magic numbers in vendor implementations for return code. 

#### How Has This Been Tested?
Non-functional change, builds successfully and can be successfully imported from at runtime. 

