### PR TITLE
[ssd_generic] Fix innodisk health regex

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -109,7 +109,7 @@ class SsdUtil(SsdBase):
         self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)
 
     def parse_innodisk_info(self):
-        self.health = self._parse_re('Health:\s*(.+?)%?', self.vendor_ssd_info)
+        self.health = self._parse_re('Health:\s*(.+?)%', self.vendor_ssd_info)
         self.temperature = self._parse_re('Temperature\s*\[\s*(.+?)\]', self.vendor_ssd_info)
 
     def parse_virtium_info(self):

--- a/tests/ssd_generic_test.py
+++ b/tests/ssd_generic_test.py
@@ -235,7 +235,7 @@ output_Innodisk_vendor_info = """***********************************************
 Model Name: InnoDisk Corp. - mSATA 3ME              
 FW Version: S140714 
 Serial Number: 20171126AAAA11730156
-Health: 0.00 
+Health: 82.34% 
 Capacity: 29.818199 GB
 P/E Cycle: 3000 
 Lifespan : 0 (Years : 0 Months : 0 Days : 0) 
@@ -397,7 +397,7 @@ class TestSsdGeneric:
 
         Innodisk_ssd.vendor_ssd_info = output_Innodisk_vendor_info
         Innodisk_ssd.parse_vendor_ssd_info('InnoDisk')
-        assert(Innodisk_ssd.get_health() == '0')
+        assert(Innodisk_ssd.get_health() == '82.34')
         assert(Innodisk_ssd.get_model() == 'InnoDisk Corp. - mSATA 3ME')
         assert(Innodisk_ssd.get_firmware() == "S140714")
         assert(Innodisk_ssd.get_temperature() == '0')


### PR DESCRIPTION
#### Description

The `heath` metric in `ssd_generic` for innodisk SSDs is too lazy. Fix to match the entire health number rather than just the first digit. 

#### How Has This Been Tested?

Manual testing on Mellanox MSN2100



